### PR TITLE
Fix null data handling in Write_File_To_Path method

### DIFF
--- a/source/StoneAge.Data.FileSystem/FileSystem.cs
+++ b/source/StoneAge.Data.FileSystem/FileSystem.cs
@@ -196,6 +196,13 @@ namespace StoneAge.FileStore
         private WriteFileResult Write_File_To_Path(IDocument file, string filePath, FileMode fileMode)
         {
             var result = new WriteFileResult();
+
+            if (file.Data == null)
+            {
+                result.ErrorMessages.Add("No file data provided; cannot write file.");
+                return result;
+            }
+
             try
             {
                 using (var stream = new FileStream(filePath, fileMode))


### PR DESCRIPTION
This pull request addresses a potential bug in the `Write_File_To_Path` method of the `FileSystem.cs` file. The method now includes a check to ensure that the `file.Data` is not null before attempting to write to the file. If `file.Data` is null, an error message is added to the `result.ErrorMessages`, and the method returns early, preventing any further execution that could lead to exceptions. This change improves the robustness of the file writing process.

---

> This pull request was co-created with Cosine Genie

Original Task: [DotnetCore-FileSystem/s7xlwblohrt1](https://cosine.sh/y41214qobygl/DotnetCore-FileSystem/task/s7xlwblohrt1)
Author: Travis Frisinger
